### PR TITLE
make grape-rabl formatter thread-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 #### Next
 
+* Make grape-rabl thread-safe. [#37](https://github.com/LTe/grape-rabl/issues/37) [@kushkella](https://github.com/kushkella)
 * Your contribution here.
 
 #### v0.3.1

--- a/lib/grape-rabl/formatter.rb
+++ b/lib/grape-rabl/formatter.rb
@@ -1,99 +1,89 @@
 require 'json'
 
 module Grape
-  module Formatter
-    module Rabl
+  module Rabl
+    class Formatter
       class << self
-        def call(object, env)
-          GrapeRabl::Formatter.new(object, env).render
+        def tilt_cache
+          @tilt_cache ||= ::Tilt::Cache.new
         end
       end
-    end
-  end
-end
 
-module GrapeRabl
-  class Formatter
-    class << self
-      def tilt_cache
-        @tilt_cache ||= ::Tilt::Cache.new
+      attr_reader :env, :endpoint, :object
+
+      def initialize(object, env)
+        @env      = env
+        @endpoint = env['api.endpoint']
+        @object   = object
       end
-    end
 
-    attr_reader :env, :endpoint, :object
-
-    def initialize(object, env)
-      @env      = env
-      @endpoint = env['api.endpoint']
-      @object   = object
-    end
-
-    def render
-      if rablable?
-        rabl do |template|
-          engine = tilt_template(template)
-          output = engine.render endpoint, locals
-          if layout_template
-            layout_template.render(endpoint) { output }
-          else
-            output
+      def render
+        if rablable?
+          rabl do |template|
+            engine = tilt_template(template)
+            output = engine.render endpoint, locals
+            if layout_template
+              layout_template.render(endpoint) { output }
+            else
+              output
+            end
           end
+        else
+          Grape::Formatter::Json.call object, env
         end
-      else
-        Grape::Formatter::Json.call object, env
       end
-    end
 
-    private
+      private
 
-    def view_path(template)
-      if template.split('.')[-1] == 'rabl'
-        File.join(env['api.tilt.root'], template)
-      else
-        File.join(env['api.tilt.root'], (template + '.rabl'))
+      def view_path(template)
+        if template.split('.')[-1] == 'rabl'
+          File.join(env['api.tilt.root'], template)
+        else
+          File.join(env['api.tilt.root'], (template + '.rabl'))
+        end
       end
-    end
 
-    def rablable?
-      !!rabl_template
-    end
-
-    def rabl
-      fail 'missing rabl template' unless rabl_template
-      set_view_root unless env['api.tilt.root']
-      yield rabl_template
-    end
-
-    def locals
-      env['api.tilt.rabl_locals'] || endpoint.options[:route_options][:rabl_locals] || {}
-    end
-
-    def rabl_template
-      env['api.tilt.rabl'] || endpoint.options[:route_options][:rabl]
-    end
-
-    def set_view_root
-      fail "Use Rack::Config to set 'api.tilt.root' in config.ru"
-    end
-
-    def tilt_template(template)
-      if Grape::Rabl.configuration.cache_template_loading
-        GrapeRabl::Formatter.tilt_cache.fetch(template) { ::Tilt.new(view_path(template), tilt_options) }
-      else
-        ::Tilt.new(view_path(template), tilt_options)
+      def rablable?
+        !!rabl_template
       end
-    end
 
-    def tilt_options
-      { format: env['api.format'], view_path: env['api.tilt.root'] }
-    end
+      def rabl
+        fail 'missing rabl template' unless rabl_template
+        set_view_root unless env['api.tilt.root']
+        yield rabl_template
+      end
 
-    def layout_template
-      layout_path = view_path(env['api.tilt.layout'] || 'layouts/application')
-      if Grape::Rabl.configuration.cache_template_loading
-        GrapeRabl::Formatter.tilt_cache.fetch(layout_path) { ::Tilt.new(layout_path, tilt_options) if File.exist?(layout_path) }
-      else
-        ::Tilt.new(layout_path, tilt_options) if File.exist?(layout_path)
+      def locals
+        env['api.tilt.rabl_locals'] || endpoint.options[:route_options][:rabl_locals] || {}
+      end
+
+      def rabl_template
+        env['api.tilt.rabl'] || endpoint.options[:route_options][:rabl]
+      end
+
+      def set_view_root
+        fail "Use Rack::Config to set 'api.tilt.root' in config.ru"
+      end
+
+      def tilt_template(template)
+        if Grape::Rabl.configuration.cache_template_loading
+          Grape::Rabl::Formatter.tilt_cache.fetch(template) { ::Tilt.new(view_path(template), tilt_options) }
+        else
+          ::Tilt.new(view_path(template), tilt_options)
+        end
+      end
+
+      def tilt_options
+        { format: env['api.format'], view_path: env['api.tilt.root'] }
+      end
+
+      def layout_template
+        layout_path = view_path(env['api.tilt.layout'] || 'layouts/application')
+        if Grape::Rabl.configuration.cache_template_loading
+          Grape::Rabl::Formatter.tilt_cache.fetch(layout_path) { ::Tilt.new(layout_path, tilt_options) if File.exist?(layout_path) }
+        else
+          ::Tilt.new(layout_path, tilt_options) if File.exist?(layout_path)
+        end
       end
     end
   end

--- a/lib/grape-rabl/formatter.rb
+++ b/lib/grape-rabl/formatter.rb
@@ -4,84 +4,96 @@ module Grape
   module Formatter
     module Rabl
       class << self
-        attr_reader :env
-        attr_reader :endpoint
-
         def call(object, env)
-          @env = env
-          @endpoint = env['api.endpoint']
+          GrapeRabl::Formatter.new(object, env).render
+        end
+      end
+    end
+  end
+end
 
-          if rablable?
-            rabl do |template|
-              engine = tilt_template(template)
-              output = engine.render endpoint, locals
-              if layout_template
-                layout_template.render(endpoint) { output }
-              else
-                output
-              end
-            end
+module GrapeRabl
+  class Formatter
+    class << self
+      def tilt_cache
+        @tilt_cache ||= ::Tilt::Cache.new
+      end
+    end
+
+    attr_reader :env, :endpoint, :object
+
+    def initialize(object, env)
+      @env      = env
+      @endpoint = env['api.endpoint']
+      @object   = object
+    end
+
+    def render
+      if rablable?
+        rabl do |template|
+          engine = tilt_template(template)
+          output = engine.render endpoint, locals
+          if layout_template
+            layout_template.render(endpoint) { output }
           else
-            Grape::Formatter::Json.call object, env
+            output
           end
         end
+      else
+        Grape::Formatter::Json.call object, env
+      end
+    end
 
-        private
+    private
 
-        def view_path(template)
-          if template.split('.')[-1] == 'rabl'
-            File.join(env['api.tilt.root'], template)
-          else
-            File.join(env['api.tilt.root'], (template + '.rabl'))
-          end
-        end
+    def view_path(template)
+      if template.split('.')[-1] == 'rabl'
+        File.join(env['api.tilt.root'], template)
+      else
+        File.join(env['api.tilt.root'], (template + '.rabl'))
+      end
+    end
 
-        def rablable?
-          !!rabl_template
-        end
+    def rablable?
+      !!rabl_template
+    end
 
-        def rabl
-          fail 'missing rabl template' unless rabl_template
-          set_view_root unless env['api.tilt.root']
-          yield rabl_template
-        end
+    def rabl
+      fail 'missing rabl template' unless rabl_template
+      set_view_root unless env['api.tilt.root']
+      yield rabl_template
+    end
 
-        def locals
-          env['api.tilt.rabl_locals'] || endpoint.options[:route_options][:rabl_locals] || {}
-        end
+    def locals
+      env['api.tilt.rabl_locals'] || endpoint.options[:route_options][:rabl_locals] || {}
+    end
 
-        def rabl_template
-          env['api.tilt.rabl'] || endpoint.options[:route_options][:rabl]
-        end
+    def rabl_template
+      env['api.tilt.rabl'] || endpoint.options[:route_options][:rabl]
+    end
 
-        def set_view_root
-          fail "Use Rack::Config to set 'api.tilt.root' in config.ru"
-        end
+    def set_view_root
+      fail "Use Rack::Config to set 'api.tilt.root' in config.ru"
+    end
 
-        def tilt_template(template)
-          if Grape::Rabl.configuration.cache_template_loading
-            tilt_cache.fetch(template) { ::Tilt.new(view_path(template), tilt_options) }
-          else
-            ::Tilt.new(view_path(template), tilt_options)
-          end
-        end
+    def tilt_template(template)
+      if Grape::Rabl.configuration.cache_template_loading
+        GrapeRabl::Formatter.tilt_cache.fetch(template) { ::Tilt.new(view_path(template), tilt_options) }
+      else
+        ::Tilt.new(view_path(template), tilt_options)
+      end
+    end
 
-        def tilt_cache
-          @tilt_cache ||= ::Tilt::Cache.new
-        end
+    def tilt_options
+      { format: env['api.format'], view_path: env['api.tilt.root'] }
+    end
 
-        def tilt_options
-          { format: env['api.format'], view_path: env['api.tilt.root'] }
-        end
-
-        def layout_template
-          layout_path = view_path(env['api.tilt.layout'] || 'layouts/application')
-          if Grape::Rabl.configuration.cache_template_loading
-            tilt_cache.fetch(layout_path) { ::Tilt.new(layout_path, tilt_options) if File.exist?(layout_path) }
-          else
-            ::Tilt.new(layout_path, tilt_options) if File.exist?(layout_path)
-          end
-        end
+    def layout_template
+      layout_path = view_path(env['api.tilt.layout'] || 'layouts/application')
+      if Grape::Rabl.configuration.cache_template_loading
+        GrapeRabl::Formatter.tilt_cache.fetch(layout_path) { ::Tilt.new(layout_path, tilt_options) if File.exist?(layout_path) }
+      else
+        ::Tilt.new(layout_path, tilt_options) if File.exist?(layout_path)
       end
     end
   end

--- a/lib/grape-rabl/render.rb
+++ b/lib/grape-rabl/render.rb
@@ -1,10 +1,12 @@
-module GrapeRabl
-  module Render
-    def render(options = {})
-      env['api.tilt.rabl'] = options[:rabl]
-      env['api.tilt.rabl_locals'] = options[:locals]
+module Grape
+  module Rabl
+    module Render
+      def render(options = {})
+        env['api.tilt.rabl'] = options[:rabl]
+        env['api.tilt.rabl_locals'] = options[:locals]
+      end
     end
   end
 end
 
-Grape::Endpoint.send(:include, GrapeRabl::Render)
+Grape::Endpoint.send(:include, Grape::Rabl::Render)

--- a/lib/grape/rabl.rb
+++ b/lib/grape/rabl.rb
@@ -1,1 +1,13 @@
 require 'grape-rabl'
+
+module Grape
+  module Formatter
+    module Rabl
+      class << self
+        def call(object, env)
+          Grape::Rabl::Formatter.new(object, env).render
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/LTe/grape-rabl/issues/37

I think tilt_cache is still not thread-safe since it is being lazy loaded and so are the templates. I'm not sure what we should do about it. The similar issue is present in ```rabl``` gem. https://github.com/nesquena/rabl/blob/776e6c5f062c0feaf26d78bb8288ee2b97a93c17/lib/rabl.rb#L59

Thanks!